### PR TITLE
Fix the app crashing in the end of the game (due to camera)

### DIFF
--- a/foosballv2s/Source/Activities/RecordingActivity.cs
+++ b/foosballv2s/Source/Activities/RecordingActivity.cs
@@ -89,6 +89,18 @@ namespace foosballv2s.Source.Activities
             var clockTimer = new Timer(new TimerCallback(UpdateGameTimer), null,  TimeSpan.FromSeconds(0), TimeSpan.FromSeconds(1));
         }
 
+        protected override void OnResume()
+        {
+            base.OnResume();
+            StartCamera();
+        }
+        
+        protected override void OnPause()
+        {
+            base.OnPause();
+            StopCamera();
+        }
+
         /// <summary>
         /// Called on the first team's goal
         /// </summary>
@@ -192,11 +204,7 @@ namespace foosballv2s.Source.Activities
         /// <returns></returns>
         public bool OnSurfaceTextureDestroyed(SurfaceTexture surface)
         {
-            if (camera != null) {
-                camera.StopPreview();
-                camera.Release();
-                camera = null;
-            }
+            StopCamera();
             return false;
         }
 
@@ -209,7 +217,7 @@ namespace foosballv2s.Source.Activities
         /// <param name="height"></param>
         public void OnSurfaceTextureAvailable(SurfaceTexture surface, int width, int height)
         {
-            camera = Camera.Open();
+            StartCamera();
             try
             {
                 camera.SetPreviewTexture(surface);
@@ -230,6 +238,31 @@ namespace foosballv2s.Source.Activities
         public void OnSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) { }
 
         public void OnSurfaceTextureUpdated(SurfaceTexture surface) { }
+
+        /// <summary>
+        /// Opens the camera if it is not already opened
+        /// </summary>
+        private void StartCamera()
+        {
+            if (camera == null)
+            {
+                camera = Camera.Open();
+            }
+        }
+
+        /// <summary>
+        /// Closes the camera (if it is open) and releases all previews related to it
+        /// </summary>
+        private void StopCamera()
+        {
+            if (camera != null) {
+                camera.SetPreviewCallback(null);
+                camera.SetPreviewTexture(null);
+                camera.StopPreview();
+                camera.Release();
+                camera = null;
+            }
+        }
 
         /// <summary>
         /// Draws a rectangle onto the screen


### PR DESCRIPTION
Sometimes there was an exception due to camera not being released properly in the RecordingActivity:
"java.lang.RuntimeException: Camera is being used after Camera.release() was called"

This happened because the camera was not properly closed. Now added needed statements for closing and releasing all textures attached to it.
